### PR TITLE
Add Middleware to de/serializer functions to support custom de/serialization for complex types

### DIFF
--- a/PSerialize/src/deserialize.py
+++ b/PSerialize/src/deserialize.py
@@ -1,5 +1,6 @@
 from typing import (
     Any,
+    Callable,
     Type,
     get_type_hints
 )
@@ -15,124 +16,93 @@ import dataclasses
 from .serialization_utils import (
     is_primitive,
     is_enum,
-    is_optional
+    is_optional,
+    get_attributes
 )
 
-def deserialize_enum(v: Any, enumType: Type[Enum]) -> Enum:
-    return enumType(v)
+class Deserializer:
+    def __init__(self, middleware: dict[type, Callable[[object], type]] = []):
+        self.middleware = middleware
 
-def get_type_hierarchy(classType: type):
-    '''
-    Returns the type hierarchy in method/variable resolution order
+    def deserialize_enum(self, v: Any, enumType: Type[Enum]) -> Enum:
+        return enumType(v)
 
-        A
-        /\----\
-       B  C    H
-       |  |    |
-       D  |    G
-         /\
-        E  F
+    def deserialize_simple_object(self, d: dict, classType: type):
+        '''
+        Constructs an instance of the given type from the supplied dictionary.
 
-    becomes
-    [A, B, D, C, E, F, H, G]   
-    '''
-    def get_bases(classType: type):
-        bases = [base for base in classType.__bases__ if base != object]
-        bases.reverse()
-        return bases
+        Any field in the dict that has no corresponding type will be set on
+        the object as its raw value.
 
-    typeHierarchy = [classType]
-    bases = get_bases(classType)
+        Currently does not support Union types
+        '''
+        attributes = get_attributes(classType)
 
-    while len(bases) > 0:
-        base = bases.pop()
-        typeHierarchy.append(base)
+        type_hints = get_type_hints(classType.__init__)
+        if dataclasses.is_dataclass(classType):
+            type_hints.pop("return", None)
+
+        # Create an empty instance of classType
+        # Some types (ex: datetime.datetime) prohibit this call
+        # and will need a custom deserializer
+        cls = object.__new__(classType)
+
+        # Sereialize any field that we can find a type hint for,
+        # otherwise set it to the raw primitve value
+        for name, value in d.items():
+            # Check if an attribute with the given name exists, but overrite 
+            # the type if it exists in the constructor type_hints
+            type = attributes.pop(name) if name in attributes.keys() else None
+            type = type_hints.pop(name) if name in type_hints.keys() else type
+            cls.__dict__[name] = self.deserialize(value, type) if type else value
+
+        if len(attributes.keys()) + len(type_hints.keys()) > 0:
+            # There are attributes or init_parameters that weren't found in the dictionary
+            pass
+
+        return cls
+
+    def deserialize_list(self, l: list, classType: type):
+        deserializedList = []
+        for value in l:
+            deserializedList.append(self.deserialize(value, classType))
+
+        return deserializedList
+
+    def deserialize_dict(self, d: dict, keyType: type, valueType: type):
+        deserializedDict = {}
+        for key, value in d.items():
+            deserializedKey = self.deserialize(key, keyType)
+            deserializedValue = self.deserialize(value, valueType)
+            deserializedDict[deserializedKey] = deserializedValue
+
+        return deserializedDict
         
-        for base in get_bases(base):
-            bases.append(base)
+    def deserialize(self, value: Any, classType: type):
+        if value == None:
+            # Allow None values
+            return None
+        if is_primitive(classType):
+            return classType(value)
+        if is_enum(classType):
+            return classType(value)
+        if is_optional(classType):
+            # If the parameter is optional, unpack the optional type and deserialize that type
+            realType = classType.__args__[0]
+            return self.deserialize(value, realType)
+        if isinstance(classType, GenericAlias):
+            typeArgs = classType.__args__
+            originType = classType.__origin__
+            if originType == type([]): # list of some type
+                typeArg = typeArgs[0] # List paramaterization only takes 1 argument
+                return self.deserialize_list(value, typeArg)
+            else:
+                keyType = typeArgs[0]
+                valueType = typeArgs[1]
+                return self.deserialize_dict(value, keyType, valueType)
+        if (deserializer := self.middleware.get(classType, None)) != None:
+            return deserializer(value)
 
-    return typeHierarchy
+        return self.deserialize_simple_object(value, classType)
 
-def get_attributes(classType: type) -> dict[str, type]:
-    attributes = {}
-    # Use the python defined method/variable resolution order to get the correct type for each attribute
-    for type in get_type_hierarchy(classType):
-        for attrName, attrType in getattr(type, '__annotations__', {}).items():
-            if attrName not in attributes.keys():
-                attributes[attrName] = attrType
-    
-    return attributes
-
-def deserialize_object(d: dict, classType: type):
-    '''
-    Constructs an instance of the given type from the supplied dictionary.
-
-    Any field in the dict that has no corresponding type will be set on
-    the object as its raw value.
-
-    Currently does not support Union types
-    '''
-    attributes = get_attributes(classType)
-
-    type_hints = get_type_hints(classType.__init__)
-    if dataclasses.is_dataclass(classType):
-        type_hints.pop("return", None)
-
-    # Create an empty instance of classType
-    cls = object.__new__(classType)
-
-    # Sereialize any field that we can find a type hint for,
-    # otherwise set it to the raw primitve value
-    for name, value in d.items():
-        # Check if an attribute with the given name exists, but overrite 
-        # the type if it exists in the constructor type_hints
-        type = attributes.pop(name) if name in attributes.keys() else None
-        type = type_hints.pop(name) if name in type_hints.keys() else type
-        cls.__dict__[name] = deserialize(value, type) if type else value
-
-    if len(attributes.keys()) + len(type_hints.keys()) > 0:
-        # There are attributes or init_parameters that weren't found in d
-        pass
-
-    return cls
-
-def deserialize_list(l: list, classType: type):
-    deserializedList = []
-    for value in l:
-        deserializedList.append(deserialize(value, classType))
-
-    return deserializedList
-
-def deserialize_dict(d: dict, keyType: type, valueType: type):
-    deserializedDict = {}
-    for key, value in d.items():
-        deserializedKey = deserialize(key, keyType)
-        deserializedValue = deserialize(value, valueType)
-        deserializedDict[deserializedKey] = deserializedValue
-
-    return deserializedDict
-    
-def deserialize(value: Any, classType: type):
-    if value == None:
-        # Allow None values
-        return None
-    if is_primitive(classType):
-        return classType(value)
-    if is_enum(classType):
-        return classType(value)
-    if is_optional(classType):
-        # If the parameter is optional, unpack the optional type and deserialize that type
-        realType = classType.__args__[0]
-        return deserialize(value, realType)
-    if isinstance(classType, GenericAlias):
-        typeArgs = classType.__args__
-        originType = classType.__origin__
-        if originType == type([]): # list of some type
-            typeArg = typeArgs[0] # List paramaterization only takes 1 argument
-            return deserialize_list(value, typeArg)
-        else:
-            keyType = typeArgs[0]
-            valueType = typeArgs[1]
-            return deserialize_dict(value, keyType, valueType)
-    else:
-        return deserialize_object(value, classType)
+default_deserializer = Deserializer(middleware={})

--- a/PSerialize/src/serialization_utils.py
+++ b/PSerialize/src/serialization_utils.py
@@ -27,4 +27,46 @@ def is_enum(type: type):
 def is_optional(typeT: type):
     origin = get_origin(typeT)
     args = get_args(typeT)
-    return origin is Union and type(None) in args 
+    return origin is Union and type(None) in args
+
+def get_type_hierarchy(classType: type):
+    '''
+    Returns the type hierarchy in method/variable resolution order
+
+        A
+        /\----\
+       B  C    H
+       |  |    |
+       D  |    G
+         /\
+        E  F
+
+    becomes
+    [A, B, D, C, E, F, H, G]   
+    '''
+    def get_bases(classType: type):
+        bases = [base for base in classType.__bases__ if base != object]
+        bases.reverse()
+        return bases
+
+    typeHierarchy = [classType]
+    bases = get_bases(classType)
+
+    while len(bases) > 0:
+        base = bases.pop()
+        typeHierarchy.append(base)
+        
+        for base in get_bases(base):
+            bases.append(base)
+
+    return typeHierarchy
+
+def get_attributes(classType: type) -> dict[str, type]:
+    attributes = {}
+    # Use the python defined method/variable resolution order to get the correct type for each attribute
+    for type in get_type_hierarchy(classType):
+        for attrName, attrType in getattr(type, '__annotations__', {}).items():
+            if attrName not in attributes.keys():
+                attributes[attrName] = attrType
+    
+    return attributes

--- a/PSerialize/src/serialize.py
+++ b/PSerialize/src/serialize.py
@@ -1,41 +1,50 @@
 
-from typing import Any
+from typing import Any, Callable
 
 from .serialization_utils import (
     is_primitive,
     is_enum
 )
 
-def serialize_object(object: object) -> dict:
-    return serialize_dict(vars(object))
+class Serializer:
+    def __init__(self, middleware: dict[type, Callable[[object], type]] = []):
+        self.middleware = middleware
 
-def serialize_dict(dict: dict) -> dict:
-    serializedDict = {}
-    for key, value in dict.items():
-        serializedKey = serialize(key)
-        serializedValue = serialize(value)
-        serializedDict[serializedKey] = serializedValue
+    def serialize_basic_object(self, object: object) -> dict:
+        return self.serialize_dict(vars(object))
 
-    return serializedDict
+    def serialize_dict(self, dict: dict) -> dict:
+        serializedDict = {}
+        for key, value in dict.items():
+            serializedKey = self.serialize(key)
+            serializedValue = self.serialize(value)
+            serializedDict[serializedKey] = serializedValue
 
-def serialize_list(list: list) -> list:
-    serializedList = []
-    for element in list:
-        serializedList.append(serialize(element))
-    
-    return serializedList
+        return serializedDict
 
-def serialize(value: Any):
-    if value == None:
-        return None
-    classType = type(value)
-    if is_primitive(classType):
-        return value
-    if is_enum(classType):
-        # Represent enums as their String representation
-        return serialize(value.value)
-    if classType is type([]):
-        return serialize_list(value)
-    if classType is type({}):
-        return serialize_dict(value)
-    return serialize_object(value)
+    def serialize_list(self, list: list) -> list:
+        serializedList = []
+        for element in list:
+            serializedList.append(self.serialize(element))
+        
+        return serializedList
+
+    def serialize(self, value: Any):
+        if value == None:
+            return None
+        classType = type(value)
+        if is_primitive(classType):
+            return value
+        if is_enum(classType):
+            # Represent enums as their String representation
+            return self.serialize(value.value)
+        if classType is type([]):
+            return self.serialize_list(value)
+        if classType is type({}):
+            return self.serialize_dict(value)
+        if (serializer := self.middleware.get(classType, None)) != None:
+            return serializer(value)
+
+        return self.serialize_basic_object(value)
+
+default_serializer = Serializer(middleware={})

--- a/PSerialize/test/tests/dataclass_test.py
+++ b/PSerialize/test/tests/dataclass_test.py
@@ -1,7 +1,6 @@
-from dataclasses import dataclass
+from  ...src.serialize import default_serializer as serializer
+from  ...src.deserialize import default_deserializer as deserializer
 
-from  ...src.serialize import serialize
-from  ...src.deserialize import deserialize
 from ..models.dataclass import (
     A
 )
@@ -15,7 +14,7 @@ def test_serialize_dataclass():
         "a": 1
     }
 
-    assert serialize(a) == expected
+    assert serializer.serialize(a) == expected
 
 def test_deserialize_dataclass():
     dct = {
@@ -24,4 +23,4 @@ def test_deserialize_dataclass():
         "a": 1
     }
     
-    assert deserialize(dct, A) == A(3.0, "bee", 1)
+    assert deserializer.deserialize(dct, A) == A(3.0, "bee", 1)

--- a/PSerialize/test/tests/enum_test.py
+++ b/PSerialize/test/tests/enum_test.py
@@ -1,9 +1,7 @@
-
 import pytest
 
-
-from  ...src.serialize import serialize
-from  ...src.deserialize import deserialize
+from  ...src.serialize import default_serializer as serializer
+from  ...src.deserialize import default_deserializer as deserializer
 
 from ..models.enum import Number
 
@@ -14,7 +12,7 @@ from ..models.enum import Number
     ({Number.FIVE: 5}, {"five": 5})
 ])
 def test_serialize_enum(input, expected):
-    assert serialize(input) == expected
+    assert serializer.serialize(input) == expected
 
 @pytest.mark.parametrize("input,type,expected", [
     ("one", Number, Number.ONE),
@@ -22,5 +20,5 @@ def test_serialize_enum(input, expected):
     ({"five": 5}, dict[Number,int], {Number.FIVE: 5})
 ])
 def test_deserialize_enum(input, type, expected):
-    assert deserialize(input, type) == expected
+    assert deserializer.deserialize(input, type) == expected
 

--- a/PSerialize/test/tests/middleware_test.py
+++ b/PSerialize/test/tests/middleware_test.py
@@ -1,0 +1,38 @@
+
+from datetime import datetime
+
+from  ...src.serialize import Serializer
+from  ...src.deserialize import Deserializer
+
+def serialize_date(value: object):
+    assert type(value) is datetime
+
+    return repr(value)
+
+def deserialize_date(value: object):
+    assert type(value) is str
+
+    arg_str = value.split("(")[1]
+    arg_str = arg_str.replace(")", "")
+    args = arg_str.strip(" ").split(",")
+    args = [int(arg) for arg in args]
+
+    return datetime(*args)
+
+serializer = Serializer(middleware={datetime: serialize_date})
+deserializer = Deserializer(middleware={datetime: deserialize_date})
+
+
+def test_serialize_datetime():
+    date = datetime(2022, 7, 25, 11, 3, 44, 21000)
+
+    serialized = serializer.serialize(date)
+
+    assert serialized == "datetime.datetime(2022, 7, 25, 11, 3, 44, 21000)"
+
+def test_deserialize_datetime():
+    date = "datetime.datetime(2022, 7, 25, 11, 3, 44, 21000)"
+
+    deserialized = deserializer.deserialize(date, datetime)
+
+    assert deserialized == datetime(2022, 7, 25, 11, 3, 44, 21000)

--- a/PSerialize/test/tests/shoe_store_test.py
+++ b/PSerialize/test/tests/shoe_store_test.py
@@ -1,6 +1,6 @@
 
-from  ...src.serialize import serialize
-from  ...src.deserialize import deserialize
+from  ...src.serialize import default_serializer as serializer
+from  ...src.deserialize import default_deserializer as deserializer
 
 from ..models.shoe_store import (
     Shelf,
@@ -20,7 +20,7 @@ def test_serialize_store():
         )
     ]
 
-    serialized = serialize(store)
+    serialized = serializer.serialize(store)
     assert serialized == [
         {
             "rows": [
@@ -52,7 +52,7 @@ def test_deserialize_store():
         }
     ]
 
-    deserialized = deserialize(json, list[Shelf])
+    deserialized = deserializer.deserialize(json, list[Shelf])
 
     assert deserialized == expected
 


### PR DESCRIPTION
Not every python type can be easily expressed solely as a dictionary of fields and their values. Some types also seem to have cpython implementations that disallow certain instantiation mechanisms (ex: datetime.datetime doesn't support calling __new__ manually. 

This PR allows users to provide custom middleware to the de/serialization functions to allow them to define their own mechanisms.