### PR TITLE
Custom serialization type

### DIFF
--- a/src/pserialize/serialize.py
+++ b/src/pserialize/serialize.py
@@ -1,5 +1,7 @@
 
-from typing import Any, Callable
+from typing import Any, Callable, Union
+
+from src.pserialize.deserialize import Deserializer, default_deserializer
 
 from .serialization_utils import (
     is_primitive,
@@ -48,5 +50,9 @@ class Serializer:
 
         return self.serialize_basic_object(value)
 
+    def serialize_into(self, value: Any, c_type: type, deserializer: Deserializer = default_deserializer):
+        serialized = self.serialize(value)
+        custom_type = deserializer.deserialize(serialized, c_type, strict=True)
+        return self.serialize(custom_type)
 
 default_serializer = Serializer(middleware={})

--- a/tests/dto_test.py
+++ b/tests/dto_test.py
@@ -1,0 +1,30 @@
+
+
+from dataclasses import dataclass
+
+from src.pserialize.serialize import default_serializer as serializer
+
+def test_serialize_into():
+    @dataclass
+    class User:
+        id: int
+        name: str
+        email: str
+        password: str # Sensitive field
+
+    @dataclass
+    class UserDTO:
+        id: int
+        name: str
+        email: str
+
+    user = User(1, "Andy", "andy@gmail.com", "super_secret")
+
+    serialized = serializer.serialize_into(user, UserDTO)
+
+    # Make sure password didn't get serialized
+    assert serialized == {
+        "id": 1,
+        "name": "Andy",
+        "email": "andy@gmail.com"
+    }


### PR DESCRIPTION
Adds strict deserialization mode that ensures only fields with a known type will be serialized
Using this strict mode we can serialize an object, deserialize it into another type (with differing fields), and re-serialize that object to effectively get custom serialization behavior. Expected use case is to serialize a DB object into a DTO, leaving out fields or changing representations of fields.